### PR TITLE
Fix build failure on Linux due to Makefile and source mismatch

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 .PHONY: all clean src/zh-kawaii.po
-all: zh-origin zh-kawaii ja-kawaii
+all: zh-origin zh_CN-kawaii ja-kawaii
 
 build:
 	mkdir -p build
@@ -7,9 +7,9 @@ build:
 %: src/%.po | build
 	msgfmt -o build/$*.mo $<
 
-src/zh-kawaii.po: src/zh-origin.po src/zh-kawaii-patch.po
-	msgcat -o src/zh-kawaii.po --no-wrap --use-first src/zh-kawaii-patch.po src/zh-origin.po
+src/zh_CN-kawaii.po: src/zh-origin.po src/zh_CN-kawaii-patch.po
+	msgcat -o src/zh_CN-kawaii.po --no-wrap --use-first src/zh_CN-kawaii-patch.po src/zh-origin.po
 
 clean:
-	rm src/zh-kawaii.po
+	rm src/zh_CN-kawaii.po
 	rm -rf build


### PR DESCRIPTION
This pull request resolves a compilation issue on Linux systems caused by inconsistencies between the Makefile and the source files in the ```src``` directory. The original Makefile referenced incorrect files ```zh-kawaii.po```, leading to build failures. After updating the Makefile to align with the actual source files, the project now compiles successfully on Linux. The changes have been tested on a clean Linux environment.

此PR修复了在 Linux 系统上因 Makefile 与 ```src``` 目录中的源文件不匹配而导致的编译问题。原有的 Makefile 引用了错误的文件 ```zh-kawaii.po```，导致构建失败。在更新 Makefile 以匹配实际的源文件后，项目现可在 Linux 上成功编译。此更改已在干净的 Linux 环境中测试通过。